### PR TITLE
Nuevo sistema de tazer.

### DIFF
--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -1493,6 +1493,10 @@ public ResetStats(playerid) {
 	SprintRaceBet[playerid] = 0;
 	SprintRaceCountdownSecs[playerid] = 11;
 	
+	/* Sistema de tazer */
+	TAZERENMANO[playerid] = 0;
+	TTAZER[playerid] = 0;
+	
  	DrugOfferType[playerid] = 0;
  	DrugOffer[playerid] = INVALID_PLAYER_ID;
 	DrugOfferPrice[playerid] = -1;


### PR DESCRIPTION
Nuevo sistema de tazer.

Se efectúa el "tazeado" con el arma 9mm silenciada [id 23], solamente si el jugador es de PMA o SIDE y esta equipado con cualquiera de los equipos excepto los GEOF o STARS.

En caso de no activar el comando "/tomartazer" miembros de la SIDE con el equipo que tiene 9mm silenciada, el arma es totalmente dañina.
