### PR TITLE
/verdeudores

### DIFF
--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -13699,7 +13699,7 @@ CMD:verdeudores(playerid, params[])
 	SendFMessage(playerid, COLOR_LIGHTYELLOW2, "Lista de cuentas bancarias cuyo balance indica una deuda hacia el estado:");
     foreach(new i : Player) {
         if(PlayerInfo[i][pBank] < 0)
-	        SendFMessage(playerid, COLOR_WHITE, "*  %s (Balance de la cuenta: {FF0000}$%s)", GetPlayerNameEx(i), PlayerInfo[i][pBank]);
+	        SendFMessage(playerid, COLOR_WHITE, "*  %s (Balance de la cuenta: {FF0000}$%s{FFFFFF})", GetPlayerNameEx(i), PlayerInfo[i][pBank]);
         }
 	return 1;
 }

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -9049,7 +9049,7 @@ CMD:ayuda(playerid,params[])
 			SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{FFDD00}[CTR-MAN]:{C8C8C8} /noticia /entrevistar");
 			
 		} else if(PlayerInfo[playerid][pFaction] == FAC_GOB) {
-			SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{FFDD00}[GOBIERNO]:{C8C8C8} /verconectados /verpresos /verantecedentes /departamento");
+			SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{FFDD00}[GOBIERNO]:{C8C8C8} /verconectados /verpresos /verantecedentes /verdeudores /departamento");
 			if(PlayerInfo[playerid][pRank] == 1) {
 			SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{FFDD00}[Líder]:{C8C8C8} /gobierno /liberar");
 			}

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -13689,6 +13689,21 @@ public OnLogAntecedentesLoad(playerid, targetname[])
 	return 1;
 }
 
+CMD:verdeudores(playerid, params[])
+{
+    if(PlayerInfo[playerid][pFaction] != FAC_GOB)
+	    return 1;
+	if(PlayerInfo[playerid][pRank] > 7) // Secretaría en adelante.
+		return SendClientMessage(playerid, COLOR_YELLOW2, "Tu rango no tiene acceso a ese comando.");
+
+	SendFMessage(playerid, COLOR_LIGHTYELLOW2, "Lista de cuentas bancarias cuyo balance indica una deuda hacia el estado:");
+    foreach(new i : Player) {
+        if(PlayerInfo[i][pBank] < 0)
+	        SendFMessage(playerid, COLOR_WHITE, "*  %s (Balance de la cuenta: {FF0000}$%s)", GetPlayerNameEx(i), PlayerInfo[i][pBank]);
+        }
+	return 1;
+}
+
 //Other
 
 CMD:p455w0rdon(playerid, params[]) {


### PR DESCRIPTION
Comando /verdeudores a pedido de Eliel para todos aquellos miembros de la facción gobierno con rango 6 o superior. (Secretaría)
Lista todos aquellos players conectados cuyo balance bancario es inferior a 0.

Sin testear, no me funciona la DB en el testserver :/, pero está hecho en base al /verconectados y teóricamente debería funcionar más que bien.