### PR TITLE
Administrativos: /quitarobjmano y /goplace

### DIFF
--- a/database/20150206-create-commands.sql
+++ b/database/20150206-create-commands.sql
@@ -68,4 +68,3 @@ INSERT INTO commands VALUES('/gametext', 4);
 INSERT INTO commands VALUES('/unknowngametext', 20);
 INSERT INTO commands VALUES('/aservicio', 1);
 INSERT INTO commands VALUES('/nivelcomando', 20);
-INSERT INTO commands VALUES('/vaciarmanos', 2);

--- a/database/20150206-create-commands.sql
+++ b/database/20150206-create-commands.sql
@@ -68,3 +68,4 @@ INSERT INTO commands VALUES('/gametext', 4);
 INSERT INTO commands VALUES('/unknowngametext', 20);
 INSERT INTO commands VALUES('/aservicio', 1);
 INSERT INTO commands VALUES('/nivelcomando', 20);
+INSERT INTO commands VALUES('/vaciarmanos', 2);

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -8081,7 +8081,7 @@ CMD:acmds(playerid, params[]) {
 CMD:admincmds(playerid, params[]) {
 
 	if(PlayerInfo[playerid][pAdmin] >= 1) {
-		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/a /ao /ajail /aservicio /getpos /gotopos /gotoplace");
+		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/a /ao /ajail /aservicio /getpos /gotopos /goplace /quitarobjmano");
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/goto /kick /mute /skin /traer /up /descongelar /congelar /slap /muteb /teleayuda (/av)hiculo");
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/vermascara /vermascaras /crearcuenta");
 	}
@@ -8162,7 +8162,7 @@ CMD:tutorial(playerid, params[])
 
 CMD:teleayuda(playerid, params[])
 {
-	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/up /gotoplace /goto /gotopos /traer");
+	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/up /gp /goto /gotopos /traer");
 	return 1;
 }
 
@@ -8929,22 +8929,27 @@ CMD:muteb(playerid, params[])
 	return 1;
 }
 
-CMD:vaciarmanos(playerid, params[])
+CMD:quitarobjmano(playerid, params[])
 {
 	new string[128],
  		hand,
 		target;
 
 	if(sscanf(params, "ui", target, hand))
-	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /vaciarmanos [IDJugador/ParteDelNombre] [1=Derecha 2=Izquierda 3=Ambas]");
+	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /quitarobjeto [IDJugador/ParteDelNombre] [Mano | 1=Derecha 2=Izquierda 3=Ambas]");
 
 	if(target != INVALID_PLAYER_ID)
 	{
 	    if(hand > 3 || hand < 1)
-			return SendClientMessage(playerid, COLOR_YELLOW2, "Mano inválida, únicamente puedes sacar el item de la mano izquierda, derecha o ambas.");
+			return SendClientMessage(playerid, COLOR_YELLOW2, "Mano inválida, únicamente puedes quitar el item de la mano izquierda, derecha o ambas.");
 
-	    format(string, sizeof(string), "[Staff] el administrador %s le ha vaciado a %s la mano %d.", GetPlayerNameEx(playerid), GetPlayerNameEx(target), hand);
-	   	AdministratorMessage(COLOR_ADMINCMD, string, 1);
+		if(hand < 3){
+	    	format(string, sizeof(string), "[Staff] el administrador %s le ha retirado a %s el objeto de la mano %d.", GetPlayerNameEx(playerid), GetPlayerNameEx(target), hand);
+		}
+ 		else {
+ 			format(string, sizeof(string), "[Staff] el administrador %s le ha retirado a %s los objetos de ambas manos.", GetPlayerNameEx(playerid), GetPlayerNameEx(target));
+		}
+		AdministratorMessage(COLOR_ADMINCMD, string, 1);
 	   	if(hand == 1) {
 	   	    SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
 	   	    PhoneHand[target] = 0;
@@ -8953,7 +8958,8 @@ CMD:vaciarmanos(playerid, params[])
 			SetHandItemAndParam(target, HAND_LEFT, 0, 0);
 		}
 		if(hand == 3) {
-		    ResetAndSaveHands(target);
+		    SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
+		    SetHandItemAndParam(target, HAND_LEFT, 0, 0);
 		    PhoneHand[target] = 0;
 		}
 	}
@@ -13129,11 +13135,16 @@ CMD:set(playerid, params[]) {
 	return 1;
 }
 
-CMD:gotoplace(playerid, params[]) {
+CMD:gp(playerid, params[]) {
+	cmd_goplace(playerid, params);
+	return 1;
+}
+
+CMD:goplace(playerid, params[]) {
 	new param[64];
 
 	if(sscanf(params, "s[64]", param)) {
-	    SendClientMessage(playerid, COLOR_GREY, "{5CCAF1}[Sintaxis]:{C8C8C8} /gotoplace [Lugar]");
+	    SendClientMessage(playerid, COLOR_GREY, "{5CCAF1}[Sintaxis]:{C8C8C8} /goplace [Lugar]");
 	    SendClientMessage(playerid, COLOR_WHITE, "Lugares: ls | sf | lv | spawn | banco");
 	} else if(strcmp(param, "ls", true) == 0) {
 	    if(GetPlayerState(playerid) == 2) {

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -8936,7 +8936,7 @@ CMD:quitarobjmano(playerid, params[])
 		target;
 
 	if(sscanf(params, "ui", target, hand))
-	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /quitarobjeto [IDJugador/ParteDelNombre] [Mano | 1=Derecha 2=Izquierda 3=Ambas]");
+	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /quitarobjmano [IDJugador/ParteDelNombre] [Mano: 1=Derecha 2=Izquierda 3=Ambas]");
 
 	if(target != INVALID_PLAYER_ID)
 	{

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -8986,6 +8986,32 @@ CMD:muteb(playerid, params[])
 	return 1;
 }
 
+CMD:vaciarmanos(playerid, params[])
+{
+	new string[128],
+ 		hand,
+		target;
+
+	if(sscanf(params, "ui", target, hand))
+	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /vaciarmanos [IDJugador/ParteDelNombre] [1=Derecha 2=Izquierda 3=Ambas]");
+
+	if(target != INVALID_PLAYER_ID)
+	{
+	    if(hand > 3 || hand < 1)
+			return SendClientMessage(playerid, COLOR_YELLOW2, "Mano inválida, únicamente puedes sacar el item de la mano izquierda, derecha o ambas.");
+
+	    format(string, sizeof(string), "[Staff] el administrador %s le ha vaciado a %s la mano %d.", GetPlayerNameEx(playerid), GetPlayerNameEx(target), hand);
+	   	AdministratorMessage(COLOR_ADMINCMD, string, 1);
+	   	if(hand == 1)
+	   	    return SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
+		if(hand == 2)
+			return SetHandItemAndParam(target, HAND_LEFT, 0, 0);
+		if(hand == 3)
+		    return ResetAndSaveHands(target);
+	}
+	return 1;
+}
+
 CMD:fly(playerid, params[])
 {
 	new Float:fAngle,

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -9002,12 +9002,17 @@ CMD:vaciarmanos(playerid, params[])
 
 	    format(string, sizeof(string), "[Staff] el administrador %s le ha vaciado a %s la mano %d.", GetPlayerNameEx(playerid), GetPlayerNameEx(target), hand);
 	   	AdministratorMessage(COLOR_ADMINCMD, string, 1);
-	   	if(hand == 1)
-	   	    return SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
-		if(hand == 2)
-			return SetHandItemAndParam(target, HAND_LEFT, 0, 0);
-		if(hand == 3)
-		    return ResetAndSaveHands(target);
+	   	if(hand == 1) {
+	   	    SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
+	   	    PhoneHand[target] = 0;
+	    }
+		if(hand == 2) {
+			SetHandItemAndParam(target, HAND_LEFT, 0, 0);
+		}
+		if(hand == 3) {
+		    ResetAndSaveHands(target);
+		    PhoneHand[target] = 0;
+		}
 	}
 	return 1;
 }

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -8942,25 +8942,27 @@ CMD:quitarobjmano(playerid, params[])
 	{
 	    if(hand > 3 || hand < 1)
 			return SendClientMessage(playerid, COLOR_YELLOW2, "Mano inválida, únicamente puedes quitar el item de la mano izquierda, derecha o ambas.");
-
-		if(hand < 3){
-	    	format(string, sizeof(string), "[Staff] el administrador %s le ha retirado a %s el objeto de la mano %d.", GetPlayerNameEx(playerid), GetPlayerNameEx(target), hand);
-		}
- 		else {
- 			format(string, sizeof(string), "[Staff] el administrador %s le ha retirado a %s los objetos de ambas manos.", GetPlayerNameEx(playerid), GetPlayerNameEx(target));
-		}
-		AdministratorMessage(COLOR_ADMINCMD, string, 1);
+			
 	   	if(hand == 1) {
-	   	    SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
-	   	    PhoneHand[target] = 0;
-	    }
-		if(hand == 2) {
+			format(string, sizeof(string), "[Staff] el administrador %s le ha retirado a %s el objeto de la mano derecha.", GetPlayerNameEx(playerid), GetPlayerNameEx(target));
+			AdministratorMessage(COLOR_ADMINCMD, string, 1);
+			SendFMessage(target, COLOR_LIGHTBLUE, "El administrador %s te ha retirado el objeto que tenías en la mano derecha.", GetPlayerNameEx(playerid), hand);
+			SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
+			PhoneHand[target] = 0;
+			
+	    } if(hand == 2) {
+			format(string, sizeof(string), "[Staff] el administrador %s le ha retirado a %s el objeto de la mano izquierda.", GetPlayerNameEx(playerid), GetPlayerNameEx(target));
+			AdministratorMessage(COLOR_ADMINCMD, string, 1);
+			SendFMessage(target, COLOR_LIGHTBLUE, "El administrador %s te ha retirado el objeto que tenías en la mano izquierda.", GetPlayerNameEx(playerid));
 			SetHandItemAndParam(target, HAND_LEFT, 0, 0);
-		}
-		if(hand == 3) {
-		    SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
-		    SetHandItemAndParam(target, HAND_LEFT, 0, 0);
-		    PhoneHand[target] = 0;
+			
+		} if(hand == 3) {
+			format(string, sizeof(string), "[Staff] el administrador %s le ha retirado a %s los objetos de ambas manos.", GetPlayerNameEx(playerid), GetPlayerNameEx(target));
+			AdministratorMessage(COLOR_ADMINCMD, string, 1);
+			SendFMessage(target, COLOR_LIGHTBLUE, "El administrador %s te ha retirado los objetos que tenías en ambas manos.", GetPlayerNameEx(playerid));
+			SetHandItemAndParam(target, HAND_RIGHT, 0, 0);
+			SetHandItemAndParam(target, HAND_LEFT, 0, 0);
+			PhoneHand[target] = 0;
 		}
 	}
 	return 1;
@@ -13142,46 +13144,50 @@ CMD:gp(playerid, params[]) {
 
 CMD:goplace(playerid, params[]) {
 	new param[64];
-
 	if(sscanf(params, "s[64]", param)) {
 	    SendClientMessage(playerid, COLOR_GREY, "{5CCAF1}[Sintaxis]:{C8C8C8} /goplace [Lugar]");
 	    SendClientMessage(playerid, COLOR_WHITE, "Lugares: ls | sf | lv | spawn | banco");
+	    
 	} else if(strcmp(param, "ls", true) == 0) {
 	    if(GetPlayerState(playerid) == 2) {
 			SetVehiclePos(GetPlayerVehicleID(playerid), 1529.6, -1691.2, 13.3);
-		}else {
+		} else {
 			SetPlayerPos(playerid, 1529.6, -1691.2, 13.3);
 		}
 		SetPlayerInterior(playerid, 0);
 		SetPlayerVirtualWorld(playerid, 0);
 		return 1;
+		
 	} else if(strcmp(param, "sf", true) == 0) {
 	   if(GetPlayerState(playerid) == 2) {
 			SetVehiclePos(GetPlayerVehicleID(playerid), -1417.0,-295.8,14.1);
-		}else {
+		} else {
 			SetPlayerPos(playerid, -1417.0,-295.8,14.1);
 		}
 		SetPlayerInterior(playerid, 0);
 		SetPlayerVirtualWorld(playerid, 0);
 		return 1;
+		
 	} else if(strcmp(param, "lv", true) == 0) {
 	    if(GetPlayerState(playerid) == 2) {
 			SetVehiclePos(GetPlayerVehicleID(playerid), 1699.2, 1435.1, 10.7);
-		}else {
+		} else {
 			SetPlayerPos(playerid, 1699.2, 1435.1, 10.7);
 		}
 		SetPlayerInterior(playerid, 0);
 		SetPlayerVirtualWorld(playerid, 0);
 		return 1;
+		
 	} else if(strcmp(param, "spawn", true) == 0) {
 	   if(GetPlayerState(playerid) == 2) {
 			SetVehiclePos(GetPlayerVehicleID(playerid), 1681.5281,-2256.2827,13.3512);
-		}else {
+		} else {
 			SetPlayerPos(playerid, 1682.9645, -2244.8215, 13.5445);
 		}
 		SetPlayerInterior(playerid, 0);
 		SetPlayerVirtualWorld(playerid, 0);
 		return 1;
+		
 	} else if(strcmp(param, "banco", true) == 0) {
  	   	SetPlayerPos(playerid, POS_BANK_X, POS_BANK_Y, POS_BANK_Z);
 		SetPlayerInterior(playerid, POS_BANK_I);

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -8081,7 +8081,7 @@ CMD:acmds(playerid, params[]) {
 CMD:admincmds(playerid, params[]) {
 
 	if(PlayerInfo[playerid][pAdmin] >= 1) {
-		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/a /ao /ajail /aservicio /getpos /gotopos /gotols /gotospawn /gotolv /gotosf");
+		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/a /ao /ajail /aservicio /getpos /gotopos /gotoplace");
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/goto /kick /mute /skin /traer /up /descongelar /congelar /slap /muteb /teleayuda (/av)hiculo");
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/vermascara /vermascaras /crearcuenta");
 	}
@@ -8162,7 +8162,7 @@ CMD:tutorial(playerid, params[])
 
 CMD:teleayuda(playerid, params[])
 {
-	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/up /gotolv /gotosf /gotols /goto /gotopos /traer /gotospawn");
+	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/up /gotoplace /goto /gotopos /traer");
 	return 1;
 }
 
@@ -8283,63 +8283,6 @@ CMD:goto(playerid, params[]) {
 			SetPlayerPos(playerid, xPos, yPos+2, zPos);
 		}
 	}
-	return 1;
-}
-
-CMD:gotols(playerid, params[]) {
-
-	if(GetPlayerState(playerid) == 2) {
-		SetVehiclePos(GetPlayerVehicleID(playerid), 1529.6, -1691.2, 13.3);
-	}else {
-		SetPlayerPos(playerid, 1529.6, -1691.2, 13.3);
-	}
-	SetPlayerInterior(playerid, 0);
-	SetPlayerVirtualWorld(playerid, 0);
-	return 1;
-}
-
-CMD:gotospawn(playerid, params[]) {
-
-	if(GetPlayerState(playerid) == 2) {
-		SetVehiclePos(GetPlayerVehicleID(playerid), 1681.5281,-2256.2827,13.3512);
-	}else {
-		SetPlayerPos(playerid, 1682.9645, -2244.8215, 13.5445);
-	}
-	SetPlayerInterior(playerid, 0);
-	SetPlayerVirtualWorld(playerid, 0);
-	return 1;
-}
-
-CMD:gotolv(playerid, params[]) {
-
-	if(GetPlayerState(playerid) == 2) {
-		SetVehiclePos(GetPlayerVehicleID(playerid), 1699.2, 1435.1, 10.7);
-	}else {
-		SetPlayerPos(playerid, 1699.2, 1435.1, 10.7);
-	}
-	SetPlayerInterior(playerid, 0);
-	SetPlayerVirtualWorld(playerid, 0);
-	return 1;
-}
-
-CMD:gotosf(playerid, params[]) {
-
-	if(GetPlayerState(playerid) == 2) {
-		SetVehiclePos(GetPlayerVehicleID(playerid), -1417.0,-295.8,14.1);
-	}else {
-		SetPlayerPos(playerid, -1417.0,-295.8,14.1);
-	}
-	SetPlayerInterior(playerid, 0);
-	SetPlayerVirtualWorld(playerid, 0);
-	return 1;
-}
-
-CMD:gotobanco(playerid, params[])
-{
-
-    SetPlayerPos(playerid, POS_BANK_X, POS_BANK_Y, POS_BANK_Z);
-	SetPlayerInterior(playerid, POS_BANK_I);
-	SetPlayerVirtualWorld(playerid, POS_BANK_W);
 	return 1;
 }
 
@@ -13182,6 +13125,57 @@ CMD:set(playerid, params[]) {
 	    } else {
 	        SendClientMessage(playerid, COLOR_WHITE, "Solo se admite un valor mayor o igual a 1 y menor o igual a 100.");
 	    }
+	}
+	return 1;
+}
+
+CMD:gotoplace(playerid, params[]) {
+	new param[64];
+
+	if(sscanf(params, "s[64]", param)) {
+	    SendClientMessage(playerid, COLOR_GREY, "{5CCAF1}[Sintaxis]:{C8C8C8} /gotoplace [Lugar]");
+	    SendClientMessage(playerid, COLOR_WHITE, "Lugares: ls | sf | lv | spawn | banco");
+	} else if(strcmp(param, "ls", true) == 0) {
+	    if(GetPlayerState(playerid) == 2) {
+			SetVehiclePos(GetPlayerVehicleID(playerid), 1529.6, -1691.2, 13.3);
+		}else {
+			SetPlayerPos(playerid, 1529.6, -1691.2, 13.3);
+		}
+		SetPlayerInterior(playerid, 0);
+		SetPlayerVirtualWorld(playerid, 0);
+		return 1;
+	} else if(strcmp(param, "sf", true) == 0) {
+	   if(GetPlayerState(playerid) == 2) {
+			SetVehiclePos(GetPlayerVehicleID(playerid), -1417.0,-295.8,14.1);
+		}else {
+			SetPlayerPos(playerid, -1417.0,-295.8,14.1);
+		}
+		SetPlayerInterior(playerid, 0);
+		SetPlayerVirtualWorld(playerid, 0);
+		return 1;
+	} else if(strcmp(param, "lv", true) == 0) {
+	    if(GetPlayerState(playerid) == 2) {
+			SetVehiclePos(GetPlayerVehicleID(playerid), 1699.2, 1435.1, 10.7);
+		}else {
+			SetPlayerPos(playerid, 1699.2, 1435.1, 10.7);
+		}
+		SetPlayerInterior(playerid, 0);
+		SetPlayerVirtualWorld(playerid, 0);
+		return 1;
+	} else if(strcmp(param, "spawn", true) == 0) {
+	   if(GetPlayerState(playerid) == 2) {
+			SetVehiclePos(GetPlayerVehicleID(playerid), 1681.5281,-2256.2827,13.3512);
+		}else {
+			SetPlayerPos(playerid, 1682.9645, -2244.8215, 13.5445);
+		}
+		SetPlayerInterior(playerid, 0);
+		SetPlayerVirtualWorld(playerid, 0);
+		return 1;
+	} else if(strcmp(param, "banco", true) == 0) {
+ 	   	SetPlayerPos(playerid, POS_BANK_X, POS_BANK_Y, POS_BANK_Z);
+		SetPlayerInterior(playerid, POS_BANK_I);
+		SetPlayerVirtualWorld(playerid, POS_BANK_W);
+		return 1;
 	}
 	return 1;
 }


### PR DESCRIPTION
- Comando /quitarobjmano, para retirar el item de una de las manos (o de ambas) de algún jugador
Agregué que modifique el PhoneHand[target] por si tiene el teléfono en la mano al momento de retirarle lo de la mano derecha, o lo de ambas manos.

- Comando /goplace -parámetro- (abreviado /gp), agrupando los actuales 5 comandos de teleport para admins en uno solo, el parámetro es a elección entre "ls, sf, lv, spawn, banco" (y en un futuro agregar los que se necesiten)


Por alguna razón, cuando subo los commits al fork, el formato me queda con separaciones de más y se ve un poco más desprolijo.
EDIT: Los probé en el testserver, y ambos comandos funcionan perfecto.