### PR TITLE
Dos fixes más para certificadores

### DIFF
--- a/gamemodes/isamp-jobs.inc
+++ b/gamemodes/isamp-jobs.inc
@@ -509,7 +509,7 @@ CMD:setjob(playerid, params[])
 	    
 	SendFMessage(targetid,COLOR_LIGHTYELLOW2,"{878EE7}[INFO]:{C8C8C8} %s te ha seteado el empleo a %d (%s).", GetPlayerNameEx(playerid), job, JobInfo[job][jName]);
 	format(string, sizeof(string), "[Staff]: %s ha seteado el empleo de %s a %d (%s).", GetPlayerNameEx(playerid), GetPlayerNameEx(targetid), job, JobInfo[job][jName]);
-	AdministratorMessage(COLOR_ADMINCMD, string, 1);
+	AdministratorMessage(COLOR_ADMINCMD, string, 2);
     PlayerInfo[targetid][pJob] = job;
 	if(job == JOB_FELON)
 		createThiefJob(targetid);

--- a/gamemodes/isamp-mask.inc
+++ b/gamemodes/isamp-mask.inc
@@ -199,7 +199,7 @@ CMD:mascara(playerid, params[])
   		PlayerTakeMaskID(playerid, random(99999999));
 		foreach(new i : Player)
 		{
-			if(PlayerInfo[i][pAdmin] < 1) // Si el tipo es admin no se lo ocultamos
+			if(PlayerInfo[i][pAdmin] < 2) // Si el tipo es admin no se lo ocultamos
 				ShowPlayerNameTagForPlayer(i, playerid, false);
 		}
 	} else


### PR DESCRIPTION
Para que no vean los nombres de usuarios enmascarados ni el msg
administrativo del /setjob