### PR TITLE
Comando /verdeudores

### DIFF
--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -13903,6 +13903,22 @@ CMD:verconectados(playerid, params[])
 	return 1;
 }
 
+CMD:verdeudores(playerid, params[])
+{
+		if(PlayerInfo[playerid][pRank] >= 7 || PlayerInfo[playerid][pFaction] != FAC_GOB)
+			return 1;
+
+   		SendFMessage(playerid, COLOR_YELLOW, "===============[Cuentas bancarias en deuda con el Estado]===============",);
+		for(new i=0; i<MAX_PLAYERS; i++)
+		{
+		    if(PlayerInfo[i][pBank] < 0)
+		        SendFMessage(playerid, COLOR_WHITE, "Cuenta bancaria de {f9fca1}%s {ffffff}- {ff0000}Balance: $%d", PlayerInfo[i][pName], PlayerInfo[i][pBank]);
+		}
+		SendClientMessage(playerid, COLOR_YELLOW, "====================================================================");
+	}
+	return 1;
+}
+
 public AntecedentesLog(playerid, targetid, antecedentes[])
 {
 	new year, month, day,

--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -9133,9 +9133,9 @@ CMD:ayuda(playerid,params[])
 			SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{FFDD00}[CTR-MAN]:{C8C8C8} /noticia /entrevistar");
 			
 		} else if(PlayerInfo[playerid][pFaction] == FAC_GOB) {
-			SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{FFDD00}[GOBIERNO]:{C8C8C8} /verconectados /verpresos /verantecedentes /departamento");
+			SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{FFDD00}[Gobierno]:{C8C8C8} /verconectados /verpresos /verantecedentes /verdeudores /liberar /departamento");
 			if(PlayerInfo[playerid][pRank] == 1) {
-			SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{FFDD00}[Líder]:{C8C8C8} /gobierno /liberar");
+			SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{FFDD00}[Líder]:{C8C8C8} /gobierno");
 			}
 
 		} else if(FactionInfo[PlayerInfo[playerid][pFaction]][fType] == FAC_TYPE_GANG) {
@@ -13908,15 +13908,14 @@ CMD:verdeudores(playerid, params[])
 		if(PlayerInfo[playerid][pRank] >= 7 || PlayerInfo[playerid][pFaction] != FAC_GOB)
 			return 1;
 
-   		SendFMessage(playerid, COLOR_YELLOW, "===============[Cuentas bancarias en deuda con el Estado]===============",);
+   		SendClientMessage(playerid, COLOR_YELLOW, "===============[Cuentas bancarias en deuda con el Estado]===============");
 		for(new i=0; i<MAX_PLAYERS; i++)
 		{
 		    if(PlayerInfo[i][pBank] < 0)
-		        SendFMessage(playerid, COLOR_WHITE, "Cuenta bancaria de {f9fca1}%s {ffffff}- {ff0000}Balance: $%d", PlayerInfo[i][pName], PlayerInfo[i][pBank]);
+		        SendFMessage(playerid, COLOR_WHITE, "Cuenta bancaria de {f9fca1}%s {ffffff}- {ff0000}Balance: %d", PlayerInfo[i][pName], PlayerInfo[i][pBank]);
 		}
 		SendClientMessage(playerid, COLOR_YELLOW, "====================================================================");
-	}
-	return 1;
+    	return 1;
 }
 
 public AntecedentesLog(playerid, targetid, antecedentes[])


### PR DESCRIPTION
- Comando utilizable por los miembros con rango menor a 7 de la facción Gobierno (Secretaría, a pedido de Eliel).
- El comando hace una lista de todas las cuentas bancarias (de la base de datos, no de los players conectados) con un balance inferior a $0.

Testeado, funciona perfecto.