### PR TITLE
Eliminadas restricciones en los comandos

### DIFF
--- a/gamemodes/isamp-adminobjects.inc
+++ b/gamemodes/isamp-adminobjects.inc
@@ -81,16 +81,12 @@ public OnPlayerEditDynamicObject(playerid, objectid, response, Float:x, Float:y,
 
 CMD:aobjetoquitar(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 2)
-        return 1;
     DeleteAdminObject(playerid);
 	return 1;
 }
 
 CMD:aobjetosquitartodo(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 2)
-        return 1;
     DeleteAllAdminObject(playerid);
 	return 1;
 }
@@ -98,9 +94,7 @@ CMD:aobjetosquitartodo(playerid, params[])
 CMD:aobjeto(playerid,params[])
 {
     new object, Float:x, Float:y, Float:z, Float:facingAngle;
-	
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
+
 	if(adminServerObjectsCant >= MAX_ADMIN_OBJECTS)
 		return SendClientMessage(playerid, COLOR_YELLOW2, "No hay mas espacio para objetos.");
     if(sscanf(params, "d", object))
@@ -115,16 +109,12 @@ CMD:aobjeto(playerid,params[])
 
 CMD:aeditobjeto(playerid,params[])
 {
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
 	EditAdminObject(playerid);
     return 1;
 }
 
 CMD:ainfoobjetos(playerid, params[])
 {
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
     SendClientMessage(playerid, COLOR_RED, "[ID objetos útiles]:");
 	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "1280: banco para sentarse - 1223: poste de luz chico - 1840: parlante - 1839: equipo de mÃºsica - 16151: barra de tragos ");
 	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "1551: botella de bebida - 1455 :vaso - 3027: porro - 2632: colchoneta de playa - 2290: sillones triples marrones - 2896,19339: ataud");

--- a/gamemodes/isamp-buildings.inc
+++ b/gamemodes/isamp-buildings.inc
@@ -165,9 +165,6 @@ CMD:abrir(playerid, params[])
 
 CMD:aedificios(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
-
 	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "[Comandos de edificios]:");
 	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/aeinfo /aeinsert - /aeremove - /aevworld - /aegetid - /aetexto - /aetexto2 - /aeentrada - /aesalida - /aecosto");
 	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/aecerrado - /aetele - /aepickup - /aefaccion - /aeradio");
@@ -178,8 +175,6 @@ CMD:aeinfo(playerid, params[])
 {
 	new id;
 
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
 	if(sscanf(params, "i", id))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aeinfo [IDedificio]");
 	if(id < 1 || id >= MAX_BUILDINGS)
@@ -198,8 +193,6 @@ CMD:aeremove(playerid, params[])
 {
 	new blid;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "d", blid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aeremove [idedificio]");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -214,8 +207,6 @@ CMD:aeinsert(playerid, params[])
 {
 	new blid, name[32], Float:entAngle, locked, fee, faction, pickupModel;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dddds[32]", fee, locked, pickupModel,  faction, name))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aeinsert [costo entrada] [locked] [modelo pickup] [faccion, 0 = n/a] [text (64 ch)]");
 	if(locked != 1 && locked != 0)
@@ -249,8 +240,6 @@ CMD:aeinsert(playerid, params[])
 
 CMD:aegetid(playerid, params[])
 {
-    if(PlayerInfo[playerid][pAdmin] < 10)
-		return 1;
 
 	for(new i = 1; i < MAX_BUILDINGS; i++)
 	{
@@ -268,8 +257,6 @@ CMD:aetexto(playerid, params[])
 {
 	new blid, text[64];
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "ds[64]", blid, text))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aetexto [idedificio] [texto 64 chars]");
  	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -288,8 +275,6 @@ CMD:aeradio(playerid, params[])
 {
 	new blid, radio;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "ii", blid, radio))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aeradio [ID edificio] [ID radio]");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -306,8 +291,6 @@ CMD:aetexto2(playerid, params[])
 {
 	new blid, text[64];
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "ds[64]", blid, text))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aetexto2 [idedificio] [texto 64 chars]");
  	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -326,8 +309,6 @@ CMD:aeentrada(playerid, params[])
 {
 	new string[128], blid, entranceInterior, Float:entranceX, Float:entranceY, Float:entranceZ, Float:entranceAngle;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "d", blid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aeentrada [idedificio] - setea la entrada a tu posición, tu ángulo será el adoptado al salir.");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -351,8 +332,6 @@ CMD:aesalida(playerid, params[])
 {
 	new string[128], blid, exitInterior, Float:exitX, Float:exitY, Float:exitZ, Float:exitAngle;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "d", blid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aesalida [idedificio] - setea la salida a tu posición, tu ángulo será el adoptado al ingresar.");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -377,8 +356,6 @@ CMD:aecosto(playerid, params[])
 {
 	new blid, cost;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", blid, cost))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aecosto [idedificio] [costo de entrada]");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -394,8 +371,6 @@ CMD:aefaccion(playerid, params[])
 {
 	new blid, faction;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", blid, faction))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aefaccion [idedificio] [facción, 0 = ninguna]");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -411,8 +386,6 @@ CMD:aepickup(playerid, params[])
 {
 	new blid, pickupModel;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", blid, pickupModel))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aepickup [idedificio] [id modelo]");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -428,8 +401,6 @@ CMD:aevworld(playerid, params[])
 {
 	new blid, vworld;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", blid, vworld))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aevworld [idedificio] [mundo virtual]");
 	if(blid < 1 || blid >= MAX_BUILDINGS)
@@ -445,8 +416,6 @@ CMD:aecerrado(playerid, params[])
 {
 	new blid, locked;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", blid, locked))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aecerrado [idedificio] [1=SI, 0=NO]");
 	if(locked < 0 || locked > 1)
@@ -468,8 +437,6 @@ CMD:aetele(playerid, params[])
 {
 	new blid;
 
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
 	if(sscanf(params, "i", blid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aetele [ID edificio]");
 	if(blid < 1 || blid >= MAX_BUILDINGS)

--- a/gamemodes/isamp-business.inc
+++ b/gamemodes/isamp-business.inc
@@ -659,8 +659,6 @@ TIMER:CancelBusinessTransfer(playerid, reason)
 
 CMD:anegocios(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 
 	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "Negocios:");
 	SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "/aninfo /aninsert /anremove /angetid /anproductos /anprecio /antipo /anradio");
@@ -673,8 +671,6 @@ CMD:aninfo(playerid, params[])
 {
 	new id;
 
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
 	if(sscanf(params, "i", id))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aninfo [IDnegocio]");
 	if(id < 1 || id >= MAX_BUSINESS)
@@ -696,9 +692,6 @@ CMD:anremove(playerid, params[]) {
 	new
 	    id;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
-
 	if(sscanf(params, "d", id)) SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anremove [idnegocio]");
 	else if(id >= 1 && id < MAX_BUSINESS) {
 		Business[id][bDelete] = true;
@@ -717,9 +710,6 @@ CMD:aninsert(playerid, params[]) {
 	    enterable,
 	    fee,
 	    price;
-
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 
 	if(sscanf(params, "ddddds[32]", fee, price, interior, locked, enterable, name))
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aninsert [costo entrada] [costo neg] [int] [locked] [tiene interior 1-0] [nombre (32ch)]");
@@ -752,8 +742,6 @@ CMD:aninsert(playerid, params[]) {
 }
 
 CMD:angetid(playerid, params[]) {
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 
 	for(new i = 0; i < MAX_BUSINESS; i++)	{
 		if(PlayerToPoint(1.0, playerid, Business[i][bOutsideX], Business[i][bOutsideY], Business[i][bOutsideZ])) {
@@ -771,8 +759,6 @@ CMD:ancaja(playerid, params[]) {
 	    bizID,
 	    money;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "ii", bizID, money))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /ancaja [idnegocio] [dinero]");
 	if(bizID >= 0 && bizID < MAX_BUSINESS) {
@@ -788,8 +774,6 @@ CMD:antele(playerid, params[])
 {
 	new bizID;
 
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
 	if(sscanf(params, "i", bizID))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /antele [IDnegocio]");
 	if(bizID < 1 || bizID >= MAX_BUSINESS)
@@ -806,8 +790,6 @@ CMD:anhabilitado(playerid, params[]) {
 	    bizID,
 	    enterable;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", bizID, enterable)) SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anhabilitado [idnegocio] [1=SI, 0=NO]");
 	else if(enterable < 0 || enterable > 1) {
 	    SendClientMessage(playerid, COLOR_ADMINCMD, "El valor no puede ser menor a 0 o mayor a 1.");
@@ -829,8 +811,6 @@ CMD:anradio(playerid,params[])
 	new radio,
 	    bizID = PlayerInfo[playerid][pBizKey];
 
-    if(PlayerInfo[playerid][pAdmin] < 1)
-		return 1;
 	if(sscanf(params, "ii", bizID, radio))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anradio [ID negocio] [ID radio]");
 	if(radio < 0 || radio > 16)
@@ -850,8 +830,6 @@ CMD:anproductos(playerid, params[])
 	    bizID,
 	    products;
 
-    if(PlayerInfo[playerid][pAdmin] < 4)
-		return 1;
 	if(sscanf(params, "dd", bizID, products))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anproductos [idnegocio] [cantidad]");
 	if(bizID >= 0 && bizID < MAX_BUSINESS)
@@ -870,8 +848,6 @@ CMD:anprecio(playerid, params[]) {
 	    bizID,
 	    price;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", bizID, price)) SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anprecio [idnegocio] [precio]");
 	else if(bizID >= 0 && bizID < MAX_BUSINESS) {
 		Business[bizID][bPrice] = price;
@@ -888,8 +864,6 @@ CMD:antipo(playerid, params[]) {
 	    bizID,
 	    type;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", bizID, type)) {
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "Tipos de negocio:");
 	    SendClientMessage(playerid, COLOR_ADMINCMD, BUSINESS_TYPES);
@@ -912,8 +886,6 @@ CMD:anvworld(playerid, params[]) {
 	    bizID,
 	    vworld;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "dd", bizID, vworld)) {
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anvworld [idnegocio] [mundo virtual]");
 	}
@@ -935,9 +907,6 @@ CMD:anentrada(playerid, params[]) {
 		Float:entranceY,
 		Float:entranceZ,
 		Float:entranceAngle;
-
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 
 	if(sscanf(params, "d", bizID)) {
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anentrada [idnegocio] - setea la entrada a tu posición, tu ángulo será el adoptado al salir.");
@@ -969,8 +938,6 @@ CMD:ansalida(playerid, params[]) {
 		Float:exitZ,
 		Float:exitAngle;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 
 	if(sscanf(params, "d", bizID)) {
 		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /ansalida [idnegocio] - setea la salida del negocio a tu posición, tu ángulo será el adoptado al ingresar.");
@@ -998,8 +965,6 @@ CMD:annombre(playerid, params[]) {
 	    bizID,
 		name[32];
 
-    if(PlayerInfo[playerid][pAdmin] < 4)
-		return 1;
 
 	if(sscanf(params, "ds[32]", bizID, name)) SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /annombre [idnegocio] [nombre 32 chars]");
 	else if(bizID >= 0 && bizID < MAX_BUSINESS && strlen(name) <= 32) {
@@ -1019,8 +984,6 @@ CMD:anvender(playerid, params[])
 	    string[128],
 	    bizID;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "i", bizID))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /anvender [ID negocio]");
 	if(bizID < 1 || bizID >= MAX_BUSINESS)

--- a/gamemodes/isamp-cardealer.inc
+++ b/gamemodes/isamp-cardealer.inc
@@ -124,9 +124,7 @@ SearchCarDealerForModel(dealer, model)
 CMD:cardealerdebug(playerid, params[])
 {
 	new dealer;
-	
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
+
 	if(sscanf(params, "i", dealer))
 	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /cardealerdebug [id consecionaria]");
 	if(dealer < 0 || dealer >= MAX_DEALERS)
@@ -144,8 +142,6 @@ CMD:playercardealerdebug(playerid, params[])
 {
 	new targetid;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
 	if(sscanf(params, "i", targetid))
 	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /playercardealerdebug [playerid]");
 	if(targetid < 0 || targetid >= MAX_PLAYERS)
@@ -171,8 +167,6 @@ CMD:agregarmodelo(playerid, params[])
 {
 	new dealer, model, carstock;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
 	if(sscanf(params, "iii", dealer, model, carstock))
 		return SendClientMessage(playerid, COLOR_YELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /agregarmodelo [ID concesionaria] [modelo] [stock] (IDs Grotti:0 - Jefferson:1)");
 	if(GetPlayerCarDealer(playerid) == -1)
@@ -215,9 +209,7 @@ CMD:agregarmodelo(playerid, params[])
 CMD:borrarmodelo(playerid, params[])
 {
 	new dealer, model;
-	
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
+
 	if(sscanf(params, "ii", dealer, model))
 		return SendClientMessage(playerid, COLOR_YELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /borrarmodelo [ID concesionaria] [modelo] (IDs Grotti:0 - Jefferson:1)");
 	if(GetPlayerCarDealer(playerid) == -1)

--- a/gamemodes/isamp-houses.inc
+++ b/gamemodes/isamp-houses.inc
@@ -894,8 +894,6 @@ CMD:casacontrato(playerid, params[])
 
 CMD:acasas(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 
 	SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{878EE7}[COMANDOS]:{C8C8C8} /acinfo - /accrear - /acborrar - /acentrada - /acsalida - /actele - /acprecio - /acvender - /acinterior");
 	SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{878EE7}[COMANDOS]:{C8C8C8} /acalquilar - /acnoalquilar");
@@ -909,8 +907,6 @@ CMD:acinterior(playerid, params[])
 	    interiorid,
 	    string[128];
 	    
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
 	if(sscanf(params, "ii", houseid, interiorid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acinterior [ID casa] [ID interior (1-42)]");
  	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1314,8 +1310,6 @@ CMD:acprecio(playerid, params[])
 		price,
 		string[128];
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
     if(sscanf(params, "ii", houseid, price))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acprecio [ID casa] [Precio]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1338,8 +1332,6 @@ CMD:acvender(playerid, params[])
 	new houseid,
 		string[128];
 	
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
     if(sscanf(params, "i", houseid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acvender [ID casa]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1388,8 +1380,6 @@ CMD:accrear(playerid, params[])
 		Float:angle,
 		string[128];
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
     if(sscanf(params, "i", price))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /accrear [Precio de la casa]");
 	if(price < 1 || price > 10000000)
@@ -1430,8 +1420,6 @@ CMD:acborrar(playerid, params[])
 	new houseid,
 		string[128];
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
     if(sscanf(params, "i", houseid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acborrar [ID casa]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1464,9 +1452,7 @@ CMD:acentrada(playerid, params[])
 	new houseid,
 		Float:angle,
 		string[128];
-		
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
+
     if(sscanf(params, "i", houseid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acentrada [ID casa]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1491,8 +1477,6 @@ CMD:acsalida(playerid, params[])
 		Float:angle,
 		string[128];
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
     if(sscanf(params, "i", houseid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acsalida [ID casa]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1514,8 +1498,6 @@ CMD:acinfo(playerid, params[])
 {
 	new id;
 
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
 	if(sscanf(params, "i", id))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acinfo [ID casa]");
 	if(id < 1 || id >= MAX_HOUSES)
@@ -1542,8 +1524,6 @@ CMD:actele(playerid, params[])
 {
 	new houseid;
 
-    if(PlayerInfo[playerid][pAdmin] < 2)
-		return 1;
 	if(sscanf(params, "i", houseid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /actele [ID casa]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1562,8 +1542,6 @@ CMD:acalquilar(playerid, params[])
 	new houseid,
 		string[128];
 
-	if(PlayerInfo[playerid][pAdmin] < 4)
-	    return 1;
     if(sscanf(params, "i", houseid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acalquilar [ID casa]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)
@@ -1588,8 +1566,6 @@ CMD:acnoalquilar(playerid, params[])
 	new houseid,
 		string[128];
 
-	if(PlayerInfo[playerid][pAdmin] < 4)
-	    return 1;
     if(sscanf(params, "i", houseid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /acnoalquilar [ID casa]");
 	if(houseid < 1 || houseid >= MAX_HOUSES)

--- a/gamemodes/isamp-jobs.inc
+++ b/gamemodes/isamp-jobs.inc
@@ -497,9 +497,6 @@ CMD:setjob(playerid, params[])
 {
 	new string[128], job, targetid;
 
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
-
 	if(sscanf(params,"ui", targetid, job))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /setjob [ID/Jugador] [id empleo]");
 	if(!IsPlayerConnected(targetid))

--- a/gamemodes/isamp-mask.inc
+++ b/gamemodes/isamp-mask.inc
@@ -250,8 +250,6 @@ CMD:vermascaras(playerid, params[])
 	new targetname[MAX_PLAYER_NAME],
 	    query[128];
 
-    if(PlayerInfo[playerid][pAdmin] < 1)
-		return 1;
     if(sscanf(params, "s[24]", targetname))
 		return SendClientMessage(playerid, COLOR_GRAD2, "{5CCAF1}[Sintaxis]:{C8C8C8} /vermascaras [Nombre del jugador] (Con el '_')");
 
@@ -266,8 +264,6 @@ CMD:vermascara(playerid, params[])
 	new maskid,
 	    query[128];
 
-    if(PlayerInfo[playerid][pAdmin] < 1)
-		return 1;
     if(sscanf(params, "i", maskid))
 		return SendClientMessage(playerid, COLOR_GRAD2, "{5CCAF1}[Sintaxis]:{C8C8C8} /vermascara [ID de la máscara]");
 

--- a/gamemodes/isamp-racesystem.inc
+++ b/gamemodes/isamp-racesystem.inc
@@ -119,8 +119,6 @@ CMD:racedebug(playerid, params[])
 {
 	new id;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
 	if(sscanf(params, "i", id))
 	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /racedebug [raceid]");
 	if(id < 0 || id >= MAX_SERVER_RACES)
@@ -142,8 +140,6 @@ CMD:playerracedebug(playerid, params[])
 {
 	new id;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
 	if(sscanf(params, "i", id))
 	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /playerracedebug [playerid]");
 	if(id < 0 || id >= MAX_PLAYERS)

--- a/gamemodes/isamp-robobanco.inc
+++ b/gamemodes/isamp-robobanco.inc
@@ -65,8 +65,6 @@ new bool:isPlayerInRobberyGroup[MAX_PLAYERS],
 
 CMD:robobancodebug(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
 
 	SendFMessage(playerid, COLOR_YELLOW, "bankRobberyCooldown = %d", bankRobberyCooldown);
 	SendFMessage(playerid, COLOR_YELLOW, "Active = %b", RobberyGroup[Active]);
@@ -82,8 +80,6 @@ CMD:playerrobobancodebug(playerid, params[])
 {
 	new id;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
 	if(sscanf(params, "i", id))
 	    return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /playerrobobancodebug [playerid]");
 	if(id < 0 || id >= MAX_PLAYERS)

--- a/gamemodes/isamp-vehicles.inc
+++ b/gamemodes/isamp-vehicles.inc
@@ -1608,8 +1608,6 @@ CMD:av(playerid, params[])
 
 CMD:avehiculo(playerid, params[])
 {
-    if(PlayerInfo[playerid][pAdmin] < 1) {
-		return 1;
 	}
 	if(PlayerInfo[playerid][pAdmin] >= 1) {
   		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "==============================[COMANDOS DE ADMIN PARA VEHICULOS]==============================");
@@ -1632,8 +1630,6 @@ CMD:avmotor(playerid, params[])
 {
 	new vehicleid;
 
-	if(PlayerInfo[playerid][pAdmin] < 1)
-		return 1;
     if(GetPlayerState(playerid) != PLAYER_STATE_DRIVER)
         return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{FF4600}[Error]:{C8C8C8} debes estar en un vehículo para utilizar este comando.");
 
@@ -1650,8 +1646,6 @@ CMD:avinfo(playerid, params[])
 {
 	new Float:hp, id;
 
-    if(PlayerInfo[playerid][pAdmin] < 1)
-		return 1;
 	if(sscanf(params, "d", id))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avinfo [idvehiculo]");
 	if(id < 1 || id >= MAX_VEH)
@@ -1676,8 +1670,6 @@ CMD:aventrar(playerid, params[])
 {
 	new vehicleid;
 
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
     if(sscanf(params, "i", vehicleid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /aventrar [idvehiculo]");
 	if(vehicleid == INVALID_VEHICLE_ID || vehicleid < 1 || vehicleid >= MAX_VEH || VehicleInfo[vehicleid][VehType] == VEH_NONE)
@@ -1691,8 +1683,6 @@ CMD:avrespawn(playerid, params[])
 {
 	new vehicleid;
 
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
     if(sscanf(params, "i", vehicleid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avrespawn [idvehiculo]");
 	if(vehicleid == INVALID_VEHICLE_ID || vehicleid < 1 || vehicleid >= MAX_VEH)
@@ -1705,8 +1695,6 @@ CMD:avrespawn(playerid, params[])
 
 CMD:avrespawnall(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
 
 	for(new i = 1; i < MAX_VEH; i++)
 	{
@@ -1725,8 +1713,6 @@ CMD:avtraer(playerid, params[])
 {
 	new Float:x, Float:y, Float:z, Float:angle, vehicleid;
 
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
 	if(sscanf(params, "i", vehicleid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avtraer [idvehiculo]");
 	if(vehicleid == INVALID_VEHICLE_ID || vehicleid < 1 || vehicleid >= MAX_VEH)
@@ -1743,8 +1729,6 @@ CMD:avfix(playerid, params[])
 {
 	new vehicleid;
 
-    if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
 	if(!IsPlayerInAnyVehicle(playerid))
         return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{FF4600}[Error]:{C8C8C8} debes estar en un vehículo para utilizar este comando.");
 
@@ -1760,8 +1744,6 @@ CMD:avfuel(playerid, params[])
 {
 	new vehicleid;
 
-    if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
 	if(!IsPlayerInAnyVehicle(playerid))
         return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{FF4600}[Error]:{C8C8C8} debes estar en un vehículo para utilizar este comando.");
 
@@ -1774,8 +1756,6 @@ CMD:avfuel(playerid, params[])
 
 CMD:avfuelcars(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
 
 	for(new c = 0; c < MAX_VEH; c++)
 	{
@@ -1788,8 +1768,6 @@ CMD:avfuelcars(playerid, params[])
 
 CMD:avfixcars(playerid, params[])
 {
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
 
 	for(new c = 0; c < MAX_VEH; c++)
 	{
@@ -1805,8 +1783,6 @@ CMD:avnitro(playerid, params[])
 {
 	new vehicleid;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
     if(!IsPlayerInAnyVehicle(playerid))
         return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{FF4600}[Error]:{C8C8C8} debes estar en un vehículo para utilizar este comando.");
 
@@ -1820,8 +1796,6 @@ CMD:avempleo(playerid, params[])
 {
 	new vehicleid, jobid;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "i", jobid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avempleo [idempleo]");
     if(!IsPlayerInAnyVehicle(playerid))
@@ -1841,8 +1815,6 @@ CMD:avfaccion(playerid, params[])
 {
 	new vehicleid, factionid;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "i", factionid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avfaccion [idfaccion]");
     if(!IsPlayerInAnyVehicle(playerid))
@@ -1862,8 +1834,6 @@ CMD:avcolor(playerid, params[])
 {
 	new vehicleid, color1, color2, Float:cx, Float:cy, Float:cz, Float:angle;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "ii", color1, color2))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avcolor [color1] [color2]");
     if(!IsPlayerInAnyVehicle(playerid))
@@ -1891,8 +1861,6 @@ CMD:avmodelo(playerid, params[])
 {
 	new vehicleid, modelid, Float:cx, Float:cy, Float:cz, Float:angle;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "i", modelid))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avmodelo [idmodelo]");
     if(!IsPlayerInAnyVehicle(playerid))
@@ -1923,8 +1891,6 @@ CMD:avtipo(playerid, params[])
 {
 	new vehicleid, type;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "i", type))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avtipo [idtipo]");
     if(!IsPlayerInAnyVehicle(playerid))
@@ -1994,8 +1960,6 @@ CMD:avestacionar(playerid, params[])
 {
 	new vehicleid, Float:cx, Float:cy, Float:cz, Float:angle;
 
-	if(PlayerInfo[playerid][pAdmin] < 3)
-		return 1;
     if(!IsPlayerInAnyVehicle(playerid))
         return SendClientMessage(playerid,COLOR_LIGHTYELLOW2,"{FF4600}[Error]:{C8C8C8} debes estar en un vehículo para utilizar este comando.");
 
@@ -2024,8 +1988,6 @@ CMD:avcrear(playerid, params[])
 {
 	new id = 1, Float:px, Float:py, Float:pz, Float:pa, modelid, color1, color2;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "iii", modelid, color1, color2))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avcrear [idmodelo] [color1] [color2]");
 	if(modelid < 400 || modelid > 611)
@@ -2059,8 +2021,6 @@ CMD:avcrearperma(playerid, params[])
 {
 	new id = 1, Float:px, Float:py, Float:pz, Float:pa, modelid, color1, color2;
 
-    if(PlayerInfo[playerid][pAdmin] < 20)
-		return 1;
 	if(sscanf(params, "iii", modelid, color1, color2))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avcrearperma [idmodelo] [color1] [color2]");
 	if(modelid < 400 || modelid > 611)
@@ -2094,8 +2054,6 @@ CMD:avhp(playerid, params[])
 {
 	new vehicleid, vhp;
 
-	if(PlayerInfo[playerid][pAdmin] < 20)
-	    return 1;
     if(sscanf(params, "ii", vehicleid, vhp))
         return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avhp [idvehiculo] [hp]");
 	if(vehicleid < 1 || vehicleid >= MAX_VEH)
@@ -2114,8 +2072,6 @@ CMD:avpatente(playerid, params[])
 {
 	new vehicleid, string[32];
 	
-	if(PlayerInfo[playerid][pAdmin] < 3)
-	    return 1;
     if(sscanf(params, "is[32]", vehicleid, string))
         return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /avpatente [idvehiculo] [patente]");
 


### PR DESCRIPTION
- Eliminé líneas que comprobaban el nivel de admin del jugador para todos los comandos administrativos de los includes, para poder modificarlos y adaptarlos al sistema de los permissions dinámicos

Habría que setear el /nivelcomando a todos los cmds que faltan antes de implementar esto, si quieren mando un commit modificando el .sql del cmdpermissions para que lo exporten directamente a la db en vez de estar cambiando uno por uno ingame