### PR TITLE
ChangeTire arreglado y un par de fixes

### DIFF
--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -10568,8 +10568,11 @@ CMD:arrastrar(playerid, params[])
 		return 1;
 	if(PlayerInfo[playerid][pRank] == 10 && PlayerInfo[playerid][pFaction] == FAC_PMA)
 		return 1;
-	if(sscanf(params, "ui", target, lugar))
-		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /arrastrar [ID/Jugador] [1/2/3]");
+	if(sscanf(params, "ui", target, lugar)){
+		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /arrastrar [ID/Jugador] [Lugar]");
+		SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Lugar]:{C8C8C8} 1 Copiloto - 2 Atras a la izquierda - 3 Atras a la derecha.");
+		return 1;
+	}
 	if(CopDuty[playerid] == 0 && SIDEDuty[playerid] == 0)
 		return SendClientMessage(playerid, COLOR_YELLOW2, "¡Debes estar en servicio!");
 	if(lugar < 1 || lugar > 3)
@@ -10584,13 +10587,10 @@ CMD:arrastrar(playerid, params[])
 		return SendClientMessage(playerid, COLOR_YELLOW2, "Vehículo o jugador incorrecto.");
 	if(VehicleInfo[vehicleid][VehFaction] != FAC_PMA && VehicleInfo[vehicleid][VehFaction] != FAC_SIDE)
 	    return SendClientMessage(playerid, COLOR_YELLOW2, "El vehículo no pertenece a tu facción.");
-	if(!ProxDetectorS(1.5, playerid, target))
+	if(!ProxDetectorS(2, playerid, target))
 	    return SendClientMessage(playerid, COLOR_YELLOW2, "El jugador se encuentra demasiado lejos.");
 
  	PutPlayerInVehicle(target, vehicleid, lugar);
- 	if (PlayerCuffed[target] != 1)
-		TogglePlayerControllable(target, true); //para que no se puedan bajar de la patrulla si los arrastran esposado.
-		
   	PlayerPlayerActionMessage(playerid, target, 15.0, "ha arrastrado al móvil a");
 	return 1;
 }
@@ -13695,10 +13695,7 @@ CMD:sacar(playerid, params[])
 	    if(vehicleid == GetPlayerVehicleID(target) && target != INVALID_PLAYER_ID)
 		{
 	        RemovePlayerFromVehicle(target);
-	        if(PlayerCuffed[target] != 1)
-        		TogglePlayerControllable(target, false); //esto los descongela si los arrastraron esposado.
-        		
-	        SendFMessage(playerid, COLOR_WHITE, "Has sacado a %s del vehículo.", GetPlayerNameEx(target));
+            SendFMessage(playerid, COLOR_WHITE, "Has sacado a %s del vehículo.", GetPlayerNameEx(target));
 	        SendFMessage(target, COLOR_WHITE, "%s te ha sacado del vehículo.", GetPlayerNameEx(playerid));
 	    }
 		else

--- a/gamemodes/isamp-mask.inc
+++ b/gamemodes/isamp-mask.inc
@@ -235,7 +235,7 @@ CMD:comprarmascara(playerid, params[])
 		return SendClientMessage(playerid, COLOR_YELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /comprarmascara [modelo]. (modelos del 0 al 12) Precio: $50.");
     if(business == 0 || (Business[business][bType] != BIZ_CLOT &&  Business[business][bType] != BIZ_CLOT2))
         return SendClientMessage(playerid, COLOR_YELLOW2, "Para comprar un pañuelo debes dirigirte a algún negocio de ropa que los venda.");
-	if(idmask < 0 || idmask > 8)
+	if(idmask < 0 || idmask > 13)
         return SendClientMessage(playerid, COLOR_YELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /comprarmascara [modelo]. (modelos del 0 al 12) Precio: $50.");
 	if(GetPlayerCash(playerid) < 50)
 	    return SendClientMessage(playerid, COLOR_YELLOW2, "No tienes el dinero suficiente, necesitas $50. ¡Vuelve cuando los tengas!");

--- a/gamemodes/isamp-vehicles.inc
+++ b/gamemodes/isamp-vehicles.inc
@@ -141,9 +141,10 @@ public ChangeTire(playerid, vehicleid)
 	UpdateVehicleDamageStatus(vehicleid, panels, doors, lights, 0);
  	TogglePlayerControllable(playerid, true);
  	
- 	if(GetHandParam(playerid, HAND_RIGHT) == ITEM_ID_RUEDA_DE_REPUESTO || (GetHandParam(playerid, HAND_LEFT) == ITEM_ID_RUEDA_DE_REPUESTO)
- 	{
+ 	if(GetHandParam(playerid, HAND_RIGHT) == ITEM_ID_RUEDA_DE_REPUESTO){
  	    SetHandItemAndParam(playerid, HAND_RIGHT, 0, 0); // Borrado lógico y grafico
+	}else{
+	    SetHandItemAndParam(playerid, HAND_LEFT, 0, 0); // Borrado lógico y grafico
 	}
 	return 1;
 }
@@ -1589,7 +1590,7 @@ CMD:vehcapot(playerid, params[])
 }
 CMD:cambiarrueda(playerid, params[])
 {
-	new vehicleid, vehicleType, panels, doors, lights, tires;
+	new vehicleid, panels, doors, lights, tires;
 	
 	if(GetPlayerState(playerid) != PLAYER_STATE_ONFOOT)
 	    return SendClientMessage(playerid, COLOR_YELLOW2, "Baja del vehículo, debes estar a pie.");

--- a/gamemodes/isamp-vehicles.inc
+++ b/gamemodes/isamp-vehicles.inc
@@ -140,6 +140,11 @@ public ChangeTire(playerid, vehicleid)
 	new panels, doors, lights;
 	UpdateVehicleDamageStatus(vehicleid, panels, doors, lights, 0);
  	TogglePlayerControllable(playerid, true);
+ 	
+ 	if(GetHandParam(playerid, HAND_RIGHT) == ITEM_ID_RUEDA_DE_REPUESTO || (GetHandParam(playerid, HAND_LEFT) == ITEM_ID_RUEDA_DE_REPUESTO)
+ 	{
+ 	    SetHandItemAndParam(playerid, HAND_RIGHT, 0, 0); // Borrado lógico y grafico
+	}
 	return 1;
 }
 
@@ -1601,15 +1606,6 @@ CMD:cambiarrueda(playerid, params[])
 	GetVehicleDamageStatus(vehicleid, panels, doors, lights, tires);
 	if(tires == 0)
 	    return SendClientMessage(playerid, COLOR_YELLOW2, "El vehículo no tiene ninguna rueda pinchada.");
-    if(!AdminDuty[playerid])
-	{
-		if( (vehicleType != VEH_FACTION && vehicleType != VEH_RENT && vehicleType != VEH_OWNED && vehicleType != VEH_JOB) ||
-			(vehicleType == VEH_FACTION && PlayerInfo[playerid][pFaction] != VehicleInfo[vehicleid][VehFaction]) ||
-			(vehicleType == VEH_OWNED && !playerHasCarKey(playerid,vehicleid)) ||
-			(vehicleType == VEH_JOB && PlayerInfo[playerid][pJob] != VehicleInfo[vehicleid][VehJob]) ||
-		 	(vehicleType == VEH_RENT && PlayerInfo[playerid][pRentCarID] != vehicleid) )
-		    return SendClientMessage(playerid, COLOR_YELLOW2, "¡No tienes las llaves de este vehículo!");
-	}
 
 	if(tires == 1 || tires == 2 || tires == 4 || tires == 8){
  		ApplyAnimation(playerid, "MISC", "PLUNGER_01", 4.0, 0, 1, 1, 0, 0);
@@ -1619,6 +1615,7 @@ CMD:cambiarrueda(playerid, params[])
 		SetPVarInt(playerid, "ChangeTire", SetTimerEx("ChangeTire", 6000, false, "iiii", playerid, vehicleid));
 		return 1;
 	}
+	
 	if(tires == 3 || tires == 5 || tires == 6 || tires == 7 || tires == 9 || tires == 10 || tires == 11 || tires == 12 || tires == 13 || tires == 14 || tires == 15)
 	    return SendClientMessage(playerid, COLOR_YELLOW2, "No puedes reparar todas las ruedas de tu vehículo, debes ir a un taller mecánico.");
 	return 0;

--- a/gamemodes/marp-tazer.inc
+++ b/gamemodes/marp-tazer.inc
@@ -97,8 +97,9 @@ CMD:tazer(playerid, params[])
     	return SendClientMessage(playerid, COLOR_YELLOW2, "¡Debes estar equipado con un tazer!");
 	if(tazerStatus[playerid] == TAZER_EMPTY)
  		return SendClientMessage(playerid, COLOR_YELLOW2, "¡Tu tazer no tiene mas munición, vuelve a la comisaría a recargarlo!");
-	if(GetHandItem(playerid, HAND_RIGHT) != 0)
-	    return SendClientMessage(playerid, COLOR_YELLOW2, "¡Tienes la mano ocupada!");
+	if(GetHandItem(playerid, HAND_RIGHT) != 0 || GetHandItem(playerid, HAND_RIGHT) != WEAPON_SILENCED)
+		return SendClientMessage(playerid, COLOR_YELLOW2, "¡Tienes la mano ocupada!");
+	
 
     if(tazerInUse[playerid] == 0)
     {


### PR DESCRIPTION
- Colocada explicación de los lugares del /arrastrar y aumentado en 0.5
el radio de detección del jugardor objetivo. Además de eliminar la línea
que congelaba al jugador.
- Cambiado el limite de idmask a 13 en el /comprarmascara.
- Agregado el borrado lógico y grafico a la rueda de repuesto además de
permitir que cualquiera pueda cambiar la rueda de cualquier coche
- Creo haber solucionado el problema que no dejaba guardar el tazer con
el comando /tazer