### PR TITLE
Modificaciones de /casaradio y /colgar

### DIFF
--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -9433,14 +9433,14 @@ CMD:colgar(playerid, params[])
 	{
 		if(caller < 255)
 		{
-		    PlayerDoMessage(playerid, 15.0, "Han colgado...");
-		    PlayerDoMessage(caller, 15.0, "Han colgado...");
+           	SendClientMessage(playerid, COLOR_YELLOW2, "Han colgado...");
+           	SendClientMessage(caller, COLOR_YELLOW2, "Han colgado...");
 			if(!IsPlayerInAnyVehicle(playerid))
 				SetPlayerSpecialAction(playerid, SPECIAL_ACTION_STOPUSECELLPHONE);
 			if(!IsPlayerInAnyVehicle(caller))
 				SetPlayerSpecialAction(caller, SPECIAL_ACTION_STOPUSECELLPHONE);
-			PlayerActionMessage(playerid,15.0,"cuelga y guarda su teléfono celular en el bolsillo.");
-			PlayerActionMessage(caller,15.0,"cuelga y guarda su teléfono celular en el bolsillo.");
+			PlayerActionMessage(playerid,15.0,"cuelga la llamada en su teléfono celular.");
+			PlayerActionMessage(caller,15.0,"cuelga la llamada en su teléfono celular.");
 			Mobile[caller] = 255;
 			if(StartedCall[playerid]) {
 			    //TODO: Implementar tiempo de llamada

--- a/gamemodes/isamp-houses.inc
+++ b/gamemodes/isamp-houses.inc
@@ -554,7 +554,7 @@ CMD:casaradio(playerid, params[])
 
 	if(sscanf(params, "i", radio))
 		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]:{C8C8C8} /casaradio [ID radio]");
-	if(houseid == 0 || houseid != PlayerInfo[playerid][pHouseKey])
+	if(houseid == 0 || houseid != PlayerInfo[playerid][pHouseKey] || houseid != PlayerInfo[playerid][pHouseKeyIncome])
  		return SendClientMessage(playerid, COLOR_YELLOW2, "No estás en tu casa.");
 	if(radio < 0 || radio > 16)
 		return SendClientMessage(playerid, COLOR_YELLOW2, "Debes ingresar una radio válida: del 1 al 16. Usa 0 para dejarlo sin radio.");


### PR DESCRIPTION
Modificado el /casaradio:
Ahora puede usarlo el inquilino. (Antes solo podía el dueño)

Modificación en /colgar:
Cambio de /do que salía de "Han colgado..." por un mensaje al usuario
que envía la misma frase.
Modificado /me que decía que guardabas el teléfono celular en tu
bolsillo cuando no lo hacías.