### PR TITLE
Sistema de GNC y virtual world cambiado al logear 

### DIFF
--- a/gamemodes/isamp-core.pwn
+++ b/gamemodes/isamp-core.pwn
@@ -108,7 +108,8 @@ forward Float:GetDistanceBetweenPlayers(p1,p2);
 
 #define HP_GAIN           		2         	                                	// Vida que ganas por segundo al estar hospitalizado.
 #define HP_LOSS           		0.1	                                           	// Vida que perdés por segundo al agonizar.
-#define GAS_UPDATE_TIME         15000                                           // Tiempo de actualizacion de la gasolina.
+#define GAS_UPDATE_TIME         15000                                           // Tiempo de actualización de la gasolina.
+#define GNC_UPDATE_TIME         5000                                            // Tiempo de actualización del GNC
 #define MAX_TEXTDRAWS           10
 #define MAX_SPAWN_ATTEMPTS 		4 												// Cantidad de intentos de spawn.
 #define MAX_LOGIN_ATTEMPTS      5
@@ -501,6 +502,7 @@ forward SoplandoPipeta(playerid);
 forward RecoverLastShot(playerid);
 forward AntecedentesLog(playerid, targetid, antecedentes[]);
 forward GetDressed(playerid, skin);
+forward PlayerVW(playerid);
 
 //==============================================================================
 
@@ -2973,6 +2975,12 @@ public accountTimer()
 	}
 }
 
+public PlayerVW(playerid)
+{
+    SetPlayerVirtualWorld(playerid, PlayerInfo[playerid][pVirtualWorld]);
+	return 1;
+}
+
 public GetDressed(playerid, skin)
 {
 	SetPlayerSkin(playerid, skin);
@@ -4588,10 +4596,10 @@ public SetPlayerSpawn(playerid)
 	    SetPlayerPos(playerid, PlayerInfo[playerid][pX], PlayerInfo[playerid][pY], PlayerInfo[playerid][pZ]);
 	    SetPlayerFacingAngle(playerid, PlayerInfo[playerid][pA]);
      	SetPlayerInterior(playerid, PlayerInfo[playerid][pInterior]);
-     	SetPlayerVirtualWorld(playerid, PlayerInfo[playerid][pVirtualWorld]);
+     	SetPlayerVirtualWorld(playerid, 1000);
+     	SetTimerEx("PlayerVW", 3000, false, "d", playerid);
      	SetCameraBehindPlayer(playerid);
 	}
-    
 	return 1;
 }
 

--- a/gamemodes/isamp-vehicles.inc
+++ b/gamemodes/isamp-vehicles.inc
@@ -81,6 +81,8 @@ enum Cars {
 	VehEcstasy,
 	VehCocaine,
 	VehRadio,
+	VehGNC,
+	VehGNCTank,
 
 	VehContainerSQLID,
 	VehContainerID
@@ -664,6 +666,8 @@ ResetVehicle(id)
     VehicleInfo[id][VehBoot]		= -1;
     VehicleInfo[id][VehLights]		= -1;
     VehicleInfo[id][VehFuel]		= 0;
+    VehicleInfo[id][VehGNCTank]     = 0;
+    VehicleInfo[id][VehGNC]         = 0;
     VehicleInfo[id][VehMarijuana]	= 0;
     VehicleInfo[id][VehLSD]			= 0;
     VehicleInfo[id][VehEcstasy]		= 0;
@@ -705,7 +709,7 @@ SaveVehicle(id)
  	}
  	VehicleInfo[id][VehEngine] = 0;
 
-	format(query,sizeof(query),"UPDATE vehicles SET VehModel=%d,VehPosX=%f,VehPosY=%f,VehPosZ=%f,VehAngle=%f,VehColor1=%d,VehColor2=%d,VehPaintjob=%d,VehFaction=%d,VehJob=%d,VehDamage1=%d,VehDamage2=%d,VehDamage3=%d,VehDamage4=%d,VehType=%d,VehOwnerID=%d,VehLocked=%d,VehEngine=%d,VehBonnet=%d,VehBoot=%d,VehLights=%d,VehFuel=%d,VehHP=%f,VehPlate='%s',VehOwnerName='%s'",
+	format(query,sizeof(query),"UPDATE vehicles SET VehModel=%d,VehPosX=%f,VehPosY=%f,VehPosZ=%f,VehAngle=%f,VehColor1=%d,VehColor2=%d,VehPaintjob=%d,VehFaction=%d,VehJob=%d,VehDamage1=%d,VehDamage2=%d,VehDamage3=%d,VehDamage4=%d,VehType=%d,VehOwnerID=%d,VehLocked=%d,VehEngine=%d,VehBonnet=%d,VehBoot=%d,VehLights=%d,VehFuel=%d, VehGNC=%d, VehGNCTank=%d, VehHP=%f,VehPlate='%s',VehOwnerName='%s'",
 		VehicleInfo[id][VehModel],
 	    VehicleInfo[id][VehPosX],
 	    VehicleInfo[id][VehPosY],
@@ -728,6 +732,8 @@ SaveVehicle(id)
 	    VehicleInfo[id][VehBoot],
 	    VehicleInfo[id][VehLights],
 	    VehicleInfo[id][VehFuel],
+	    VehicleInfo[id][VehGNC],
+	    VehicleInfo[id][VehGNCTank],
 		VehicleInfo[id][VehHP],
 		VehicleInfo[id][VehPlate],
 		VehicleInfo[id][VehOwnerName]

--- a/gamemodes/marp-mechanic.inc
+++ b/gamemodes/marp-mechanic.inc
@@ -688,9 +688,9 @@ CMD:mecaceptar(playerid, params[])
 			if(GNCOffer[playerid] == 999)
 			    return SendClientMessage(playerid, COLOR_YELLOW2, "Ningún mecánico te ofreció instalar un tanque de GNC en tu vehículo.");
 			if(!IsPlayerConnected(GNCOffer[playerid]))
-			    return SendClientMessage(playerid, COLOR_YELLOW2, "El soplapollas no está conectado.");
+			    return SendClientMessage(playerid, COLOR_YELLOW2, "El mecánico no está conectado.");
 			if(!IsPlayerInRangeOfPoint(playerid, MEC_REPAIR_RANGE, MEC_REPAIR_PLACE_X, MEC_REPAIR_PLACE_Y, MEC_REPAIR_PLACE_Z))
-			    return SendClientMessage(playerid, COLOR_YELLOW2, "Debes estar en el area de reparaciones de mercury XD");
+			    return SendClientMessage(playerid, COLOR_YELLOW2, "Debes estar en el area de reparaciones del taller Mercury.");
 			if(!ProxDetectorS(5.0, playerid, GNCOffer[playerid]))
 			    return SendClientMessage(playerid, COLOR_YELLOW2, "Estas muy lejos del sujeto");
 			if(GetPlayerState(playerid) != PLAYER_STATE_DRIVER)

--- a/gamemodes/marp-mechanic.inc
+++ b/gamemodes/marp-mechanic.inc
@@ -89,6 +89,7 @@ new CarLiftState[4] = 0,
 #define MEC_OFFER_CERRADURA     	2
 #define MEC_OFFER_TUNING        	3
 #define MEC_OFFER_DESTUNING     	4
+#define MEC_OFFER_GNC               5
 
 //==============================DATA STORAGE====================================
 
@@ -97,7 +98,11 @@ new RepairClient[MAX_PLAYERS],
 	RepairProducts[MAX_PLAYERS],
 	RepairPrice[MAX_PLAYERS],
 	RepairType[MAX_PLAYERS],
-	RepairOfferTimer[MAX_PLAYERS];
+	RepairOfferTimer[MAX_PLAYERS],
+	// GNC Variables
+	GNCOffer[MAX_PLAYERS],
+	GNCClient[MAX_PLAYERS],
+	GNCTimer[MAX_PLAYERS];
 
 new TMTuneTimers[5];
 
@@ -105,12 +110,13 @@ new TMTuneTimers[5];
 
 forward ResetRepairOffer(playerid);
 forward EndRepairOffer(playerid);
-
+forward EndGNCOffer(playerid);
+forward ResetGNCOffer(playerid);
 forward Cerrajeria(playerid);
 forward AutoReparacion(playerid, paynsprayid);
 forward Reparacion(playerid);
 forward Destuning(playerid);
-
+forward GncInstall(playerid);
 forward GetRepairMaterialCost(vehicleid);
 
 forward CloseTuneGate(gate);
@@ -151,6 +157,21 @@ public EndRepairOffer(playerid)
 	RepairClient[RepairOffer[playerid]] = 999;
     ResetRepairOffer(playerid);
     return 1;
+}
+
+public EndGNCOffer(playerid)
+{
+	GNCClient[GNCOffer[playerid]] = 999;
+	ResetGNCOffer(playerid);
+	return 1;
+}
+
+
+public ResetGNCOffer(playerid)
+{
+	GNCClient[playerid] = 999;
+	GNCOffer[playerid] = 999;
+	return 1;
 }
 
 stock GetRepairMaterialCost(vehicleid)
@@ -269,6 +290,21 @@ public Destuning(playerid)
 	SendFMessage(RepairOffer[playerid], COLOR_WHITE, "Has removido las partes tuning del vehículo de %s.", GetPlayerNameEx(playerid));
 	TogglePlayerControllable(playerid, true);
 	EndRepairOffer(playerid);
+	return 1;
+}
+
+public GncInstall(playerid)
+{
+	new vehicleid = GetPlayerVehicleID(playerid);
+	new mecanico = GNCOffer[playerid];
+
+	VehicleInfo[vehicleid][VehGNCTank] = 1;
+	VehicleInfo[vehicleid][VehGNC] = 0;
+	SaveVehicle(vehicleid);
+	SendFMessage(playerid, -1, "El tanque de GNC fue instalado en tu vehículo por %s.", GetPlayerNameEx(GNCOffer[playerid]));
+	SendFMessage(mecanico, -1, "Instalaste el tanque de GNC en el vehículo de %s", GetPlayerNameEx(playerid));
+	TogglePlayerControllable(playerid, true);
+	EndGNCOffer(playerid);
 	return 1;
 }
 
@@ -646,6 +682,25 @@ CMD:mecaceptar(playerid, params[])
   			RepairClient[RepairOffer[playerid]] = playerid;
 			SendClientMessage(playerid, COLOR_WHITE, "Has aceptado la propuesta de tuneo.");
 			SendClientMessage(RepairOffer[playerid], COLOR_WHITE, "Han aceptado tu propuesta, usa /mectuning estando como conductor del vehículo a tunear.");
+		}
+		case MEC_OFFER_GNC:
+		{
+			if(GNCOffer[playerid] == 999)
+			    return SendClientMessage(playerid, COLOR_YELLOW2, "Ningún mecánico te ofreció instalar un tanque de GNC en tu vehículo.");
+			if(!IsPlayerConnected(GNCOffer[playerid]))
+			    return SendClientMessage(playerid, COLOR_YELLOW2, "El soplapollas no está conectado.");
+			if(!IsPlayerInRangeOfPoint(playerid, MEC_REPAIR_RANGE, MEC_REPAIR_PLACE_X, MEC_REPAIR_PLACE_Y, MEC_REPAIR_PLACE_Z))
+			    return SendClientMessage(playerid, COLOR_YELLOW2, "Debes estar en el area de reparaciones de mercury XD");
+			if(!ProxDetectorS(5.0, playerid, GNCOffer[playerid]))
+			    return SendClientMessage(playerid, COLOR_YELLOW2, "Estas muy lejos del sujeto");
+			if(GetPlayerState(playerid) != PLAYER_STATE_DRIVER)
+			    return SendClientMessage(playerid, COLOR_YELLOW2, "Debes estar de conductor");
+
+			GameTextForPlayer(playerid, "El mecanico esta instalando el tanque en tu vehiculo", 4000, 1);
+			GameTextForPlayer(GNCOffer[playerid], "Instalando tanque de GNC", 400, 1);
+           	KillTimer(GNCTimer[playerid]);
+			TogglePlayerControllable(playerid, false);
+			SetTimerEx("GncInstall", 5000, false, "d", playerid);
 		}
 	}
 	return 1;
@@ -1687,5 +1742,33 @@ CMD:mecpuertadepo(playerid, params[])
 			CarDepotDoorState[0] = 0;
 		}
 	}
+	return 1;
+}
+
+CMD:mecgnc(playerid, params[])
+{
+	new targetid,
+	    vehicleid = GetPlayerVehicleID(playerid);
+
+	if(sscanf(params, "u", targetid))
+		return SendClientMessage(playerid, COLOR_LIGHTYELLOW2, "{5CCAF1}[Sintaxis]{C8C8C8} /mecgnc [ID del jugador]");
+	if(!IsPlayerConnected(targetid) || targetid == INVALID_PLAYER_ID)
+		return SendClientMessage(playerid, COLOR_YELLOW2, "Jugador inválido o no conectado.");
+	if(!IsPlayerInRangeOfPoint(playerid, MEC_REPAIR_RANGE, MEC_REPAIR_PLACE_X, MEC_REPAIR_PLACE_Y, MEC_REPAIR_PLACE_Z))
+	    return SendClientMessage(playerid, COLOR_YELLOW2, "Sólo puedes usar éste comando en el taller mecánico.");
+	if(GetPlayerState(targetid) != PLAYER_STATE_DRIVER)
+	    return SendClientMessage(playerid, COLOR_YELLOW2, "El jugador debe estar de conductor en un vehículo.");
+	if(GNCClient[playerid] < 999)
+	    return SendClientMessage(playerid, COLOR_YELLOW2, "Ya tienes una oferta de trabajo con otro cliente.");
+	if(targetid == playerid)
+	    return SendClientMessage(playerid, COLOR_YELLOW2, "No podés instalartelo a vos mismo.");
+	if(GetVehicleType(vehicleid) != VTYPE_CAR)
+	    return SendClientMessage(playerid, COLOR_YELLOW2, "Sólo es posible instalar un tanque de GNC en autos.");
+
+	SendFMessage(playerid, COLOR_LIGHTBLUE, "Le ofreciste a %s instalar un tanque de GNC en su vehículo y tiene 15 segundos para responder.", GetUserName(targetid));
+	SendFMessage(targetid, COLOR_LIGHTBLUE, "%s te ofreció instalar un tanque de GNC en tu vehículo y tienes 15 segundos para aceptarlo (/aceptar).", GetUserName(playerid));
+	GNCOffer[targetid] = playerid;
+	GNCClient[playerid] = targetid;
+	GNCTimer[targetid] = SetTimerEx("EndGNCOffer", 15000, false, "d", targetid);
 	return 1;
 }


### PR DESCRIPTION
Al logear al servidor se activa un timer de 3 segundos que nos lleva al
vw 1000 para evitar problemas con la carga simultanea de objetos
dinámicos y vehículos.
También mando el sistema de GNC, le falta comando para alternar entre
gas y nafta y adaptarlo al /llenar y la db, pero mas allá de eso debería
funcionar correctamente. Omitan lo de soplapollas jajaj